### PR TITLE
Fix for SDK 4.0.0

### DIFF
--- a/android/src/dk/napp/drawer/DrawerProxy.java
+++ b/android/src/dk/napp/drawer/DrawerProxy.java
@@ -135,7 +135,7 @@ public class DrawerProxy extends TiWindowProxy implements TiActivityWindow
 	}
 
 	@Override
-	public void windowCreated(TiBaseActivity activity) {
+	public void windowCreated(TiBaseActivity activity, Bundle savedInstanceState) {
 		slideMenuActivity = new WeakReference<Activity>(activity);
 		activity.setWindowProxy(this);
 		setActivity(activity);


### PR DESCRIPTION
extended class TiWindowProxy implements the method

public void windowCreated(TiBaseActivity activity, Bundle savedInstanceState)

and the line at 139 implements the method as

public void windowCreated(TiBaseActivity activity)

Thus causing an AbstractMethodError ---