### PR TITLE
Updated for Appcelerator SDK 4.1.0.GA

### DIFF
--- a/android/lib/README
+++ b/android/lib/README
@@ -1,0 +1,2 @@
+You can place any .jar dependencies in this directory and they will be included
+when your module is being compiled.

--- a/android/src/dk/napp/drawer/Drawer.java
+++ b/android/src/dk/napp/drawer/Drawer.java
@@ -26,7 +26,7 @@ import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiUIView;
 
-import ti.modules.titanium.ui.WindowProxy;
+import org.appcelerator.titanium.proxy.TiWindowProxy;
 
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -333,7 +333,7 @@ public class Drawer extends TiUIView implements ConfigurationChangedListener{
 		if (d.containsKey(PROPERTY_LEFT_VIEW)) {
 			Object leftView = d.get(PROPERTY_LEFT_VIEW);
 			if (leftView != null && leftView instanceof TiViewProxy) {
-				if (leftView instanceof WindowProxy)
+				if (leftView instanceof TiWindowProxy)
 					throw new IllegalStateException("[ERROR] Cannot use window as SlideMenu view");
 				this.leftView = (TiViewProxy)leftView;
 			} else {
@@ -343,7 +343,7 @@ public class Drawer extends TiUIView implements ConfigurationChangedListener{
 		if (d.containsKey(PROPERTY_RIGHT_VIEW)) {
 			Object rightView = d.get(PROPERTY_RIGHT_VIEW);
 			if (rightView != null && rightView instanceof TiViewProxy) {
-				if (rightView instanceof WindowProxy)
+				if (rightView instanceof TiWindowProxy)
 					throw new IllegalStateException("[ERROR] Cannot use window as SlideMenu view");
 				this.rightView = (TiViewProxy)rightView;
 			} else {
@@ -354,7 +354,7 @@ public class Drawer extends TiUIView implements ConfigurationChangedListener{
 		if (d.containsKey(PROPERTY_CENTER_VIEW)) {
 			Object centerView = d.get(PROPERTY_CENTER_VIEW);
 			if (centerView != null && centerView instanceof TiViewProxy) {
-				if (centerView instanceof WindowProxy)
+				if (centerView instanceof TiWindowProxy)
 					throw new IllegalStateException("[ERROR] Cannot use window as SlideMenu view");
 				
 				this.centerView = (TiViewProxy)centerView;
@@ -432,7 +432,7 @@ public class Drawer extends TiUIView implements ConfigurationChangedListener{
 			if (newValue == this.leftView) return;
 			TiViewProxy newProxy = null;
 			if (newValue != null && newValue instanceof TiViewProxy) {
-				if (newValue instanceof WindowProxy)
+				if (newValue instanceof TiWindowProxy)
 					throw new IllegalStateException("Cannot use window as SlideMenu view");
 				newProxy = (TiViewProxy)newValue;
 			} else {
@@ -444,7 +444,7 @@ public class Drawer extends TiUIView implements ConfigurationChangedListener{
 			if (newValue == this.rightView) return;
 			TiViewProxy newProxy = null;
 			if (newValue != null && newValue instanceof TiViewProxy) {
-				if (newValue instanceof WindowProxy)
+				if (newValue instanceof TiWindowProxy)
 					throw new IllegalStateException("Cannot use window as SlideMenu view");
 				newProxy = (TiViewProxy)newValue;
 			} else {
@@ -461,7 +461,7 @@ public class Drawer extends TiUIView implements ConfigurationChangedListener{
 				index = content.indexOfChild(this.centerView.getOrCreateView().getNativeView());
 			}
 			if (newValue != null && newValue instanceof TiViewProxy) {
-				if (newValue instanceof WindowProxy)
+				if (newValue instanceof TiWindowProxy)
 					throw new IllegalStateException("Cannot use window as SlideMenu view");
 				newProxy = (TiViewProxy)newValue;
 				TiCompositeLayout.LayoutParams params = new TiCompositeLayout.LayoutParams();

--- a/android/src/dk/napp/drawer/DrawerProxy.java
+++ b/android/src/dk/napp/drawer/DrawerProxy.java
@@ -21,6 +21,7 @@ import org.appcelerator.titanium.TiActivityWindow;
 import org.appcelerator.titanium.TiActivityWindows;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBaseActivity;
+import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.proxy.TiWindowProxy;
@@ -217,9 +218,10 @@ public class DrawerProxy extends TiWindowProxy implements TiActivityWindow
 	}
 
 	@Override
-	public KrollDict handleToImage()
+	public TiBlob handleToImage()
 	{
-		return TiUIHelper.viewToImage(new KrollDict(), getActivity().getWindow().getDecorView());
+		KrollDict d = TiUIHelper.viewToImage(new KrollDict(), getActivity().getWindow().getDecorView());
+		return TiUIHelper.getImageFromDict(d);
 	}
 
 	@Override


### PR DESCRIPTION
Addition of **android/lib** folder structure, as the current SDK/CLI release at the current time of writing breaks the compile in Appcelerator Studio if the **android/lib** folder is missing.