### PR TITLE
Bump minSDK to 7.0.0

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -15,4 +15,4 @@ name: nappslide
 moduleid: dk.napp.drawer
 guid: 0f157d47-db5c-4891-8197-c851e8d329e0
 platform: android
-minsdk: 6.2.0
+minsdk: 7.0.0


### PR DESCRIPTION
@viezel  Android native module api level 4 is now slated for SDK 7.0.0 instead of 6.2.0. We've pushed off the V8 update to 7.0.0 release since it'd be a breaking android native module change.

So If you're targeting a release for 7.0.0 eventually (slated for November release, but is our current `master` branch) you'll want api level `4` and minSDK `7.0.0`, with a major version rev bump (so of you, looks like the `2.x` line). I had filed a PR that you merged to get ready for this. You may want to move this over to a branch to be ready for 7.0.0 since it'll be a while until it comes out now.

For SDK 4.1.0.GA up to 7.0.0, you'll want minSDK `4.1.0.GA` and `apiLevel` `3`, and can keep the current major version rev line you had (`1.x`)

I apologize for submitting the other PR so early, but we expected the V8 update to ship much earlier (like now).